### PR TITLE
Add Aire ^2.0 constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1",
-    "glhd/aire": "^1.6.0|dev-*",
+    "glhd/aire": "^1.6.0|^2.0|dev-*",
     "illuminate/support": "^5.7|^6.0|^7.0"
   },
   "require-dev": {


### PR DESCRIPTION
Having trouble installing on Laravel 7, seems that composer doesn't like the `dev-*` constraint for the main Aire package? I think adding the 2.0 constraint should fix.

```
 Problem 1
    - Installation request for glhd/aire-tailwind-custom-forms dev-master@dev -> satisfiable by glhd/aire-tailwind-custom-forms[dev-master].
    - glhd/aire-tailwind-custom-forms dev-master requires glhd/aire ^1.6.0|dev-* -> satisfiable by glhd/aire[1.10.0, 1.6.0, 1.6.1, 1.7.1, 1.8.0, 1.8.1, 1.9.0, 1.9.1] but these conflict with your requirements or minimum-stability.
 Problem 2
    - Conclusion: don't install laravel/framework v7.5.2
```

